### PR TITLE
fix: remove broken rule from stylelint config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,6 @@
 {
   "rules": {
     "no-invalid-double-slash-comments": true,
-    "no-extra-semicolons": true,
     "no-duplicate-selectors": true,
     "font-family-no-duplicate-names": true,
     "declaration-block-no-shorthand-property-overrides": true,


### PR DESCRIPTION
I removed a rule Stylelint no longer recognizes and only gives errors for. 

This is the console output that the having the rule gives. 

```
  1:1  ✖  Unknown rule no-extra-semicolons  no-extra-semicolons
``` 